### PR TITLE
add option to GetFile to export dag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 proto/
 server/server
 test_client/test_client
+ipfs-api-server/ipfs-api-server

--- a/test_client/main.go
+++ b/test_client/main.go
@@ -112,6 +112,25 @@ func main() {
 				log.Fatalf("GetFile should return result")
 			}
 		}
+	case "dag-export":
+		getRequest := pb.GetFileRequest{
+			IpfsPath:   *argPtr,
+			Log2Size:   0,
+			OutputPath: "/tmp/outout_dag",
+			Timeout:    30,
+			ExportDag:  true,
+		}
+
+		r, err := getFile(ctx, &getRequest, &c)
+
+		if err != nil {
+			log.Fatalf("Could not GetFile with ExportDag=True: %v", err)
+		} else {
+			switch r.GetGetOneof().(type) {
+			case *pb.GetFileResponse_Progress:
+				log.Fatalf("GetFile with ExportDag=True should return result")
+			}
+		}
 	case "test":
 		// Test GetFile error when the file doesn't exist
 		// Should return timeout error after 5 seconds


### PR DESCRIPTION
1. GetFile now can export DAG of specified file. CAR file is saved locally.
2. Update test-client to test dag export in minimal way.
3. Update grpc-interfaces dep.
4. Update gitignore.